### PR TITLE
Workaround for comments with leading or trailing `\s` character(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ async function run() {
     const body =
         (context.eventName === "issue_comment"
         // For comments on pull requests
-            ? context.payload.comment.body
+            ? context.payload.comment.body.trim()
             // For the initial pull request description
-            : context.payload.pull_request.body) || '';
+            : context.payload.pull_request.body.trim()) || '';
     core.setOutput('comment_body', body);
 
     if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pull-request-comment-trigger",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pull-request-comment-trigger",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pull-request-comment-trigger",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Sometimes a user might add a `\s` (e.g. `\n`) at the end of the comment unintentionally and then would be confused as to why the trigger wouldn't work as expected 🙈

This pull request trims the comment body before doing the regex match as a workaround.