### PR TITLE
Allow trigger to be inside of the body, not necessarily at the beginning

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31116,7 +31116,7 @@ async function run() {
     const prefixOnly = core.getInput("prefix_only") === 'true';
     const allowArguments = core.getInput("allow_arguments") === 'true';
 
-    let hasTrigger = body.startsWith(trigger);
+    let hasTrigger = (prefixOnly && body.startsWith(trigger)) || body.includes(trigger);
 
     if (allowArguments) {
         let regexRawTrigger = trigger.replace(/\s\*{2}/g, ' [^\\s]+');
@@ -31132,7 +31132,7 @@ async function run() {
         hasTrigger = regexTrigger.test(body);
     }
 
-    if ((prefixOnly && !hasTrigger) || !hasTrigger) {
+    if (!hasTrigger) {
         core.setOutput("triggered", "false");
         return;
     }


### PR DESCRIPTION
Allow the body to include the trigger without having to be at the beginning and take note of `prefixOnly`. 

It was counter-intuitive to have the `prefixOnly` option unset (default `false`) and notice that the workflow(s) is not triggered when the trigger word was in the middle of the Pull Request body (or at the end of it).

This PR aims to fix that behavior. 